### PR TITLE
fix: edit broken link for AWS guide

### DIFF
--- a/guides/aws/aws.md
+++ b/guides/aws/aws.md
@@ -1,3 +1,3 @@
 # Example Setup with AWS
 
-Please check the [aws folders readme file](../aws/README.md).
+Please check the [aws folders readme file](../../aws/README.md).


### PR DESCRIPTION
Signed-off-by: osamamagdy <osamamagdy174@gmail.com>
When I was going through the documentation for AWS, noticed a 404 error. 