### PR TITLE
fix: use quote function to guarentee all crons

### DIFF
--- a/helm/wrongsecrets-ctf-party/templates/cleanup/cron-job.yaml
+++ b/helm/wrongsecrets-ctf-party/templates/cleanup/cron-job.yaml
@@ -8,7 +8,7 @@ kind: CronJob
 metadata:
   name: 'cleanup-job'
 spec:
-  schedule: {{ .Values.wrongsecretsCleanup.cron }}
+  schedule: {{ .Values.wrongsecretsCleanup.cron | quote }}
   successfulJobsHistoryLimit: {{ .Values.wrongsecretsCleanup.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.wrongsecretsCleanup.failedJobsHistoryLimit }}
   jobTemplate:


### PR DESCRIPTION
If you tried to use a cron schedule value like `*/2 * * * *` it will fail with the error 
`Error: UPGRADE FAILED: YAML parse error on wrongsecrets-ctf-party/templates/cleanup/cron-job.yaml: error converting YAML to JSON: yaml: line 6: did not find expected alphabetic or numeric character`
The reason of this is that Helm doesn't always quote all values by default so we need to pipe it to the `quote` function.