### PR TITLE
fix(balancer): stop execution after intermediate team provisioning failures

### DIFF
--- a/wrongsecrets-balancer/src/teams/teams.js
+++ b/wrongsecrets-balancer/src/teams/teams.js
@@ -296,7 +296,7 @@ async function createTeam(req, res) {
     await createNameSpaceForTeam(team);
   } catch (error) {
     logger.error(`Error while creating namespace for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating Configmap for team '${team}'`);
@@ -306,14 +306,14 @@ async function createTeam(req, res) {
     await createSecretsfileForTeam(team);
   } catch (error) {
     logger.error(`Error while creating secretsfile or configmap for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating challenge33 for team '${team}'`);
     await createChallenge33SecretForTeam(team);
   } catch (error) {
     logger.error(`Error while creating challenge33 secretsfile ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating challenge62 secret and configmap for team '${team}'`);
@@ -321,7 +321,7 @@ async function createTeam(req, res) {
     await createChallenge62ConfigMapForTeam(team);
   } catch (error) {
     logger.error(`Error while creating challenge62 resources for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating WrongSecrets Deployment for team '${team}' with k8s (no cloud)`);
@@ -331,7 +331,7 @@ async function createTeam(req, res) {
     logger.error(
       `Error while creating wrongsecrets deployment or service for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating service account for virtual desktop in K8s '${team}'`);
@@ -341,7 +341,7 @@ async function createTeam(req, res) {
     logger.error(
       `Error while creating service account for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -350,7 +350,7 @@ async function createTeam(req, res) {
     logger.info(`Created challenge53 Deployment for team '${team}'`);
   } catch (error) {
     logger.error(`Error while creating challenge53 deployment for team ${team}: ${error.message}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -361,7 +361,7 @@ async function createTeam(req, res) {
     logger.error(
       `Error while creating role for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -372,7 +372,7 @@ async function createTeam(req, res) {
     logger.error(
       `Error while creating roleBinding for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating virtualdesktop Deployment for team '${team}'`);
@@ -384,7 +384,7 @@ async function createTeam(req, res) {
     logger.error(
       `Error while creating Virtualdesktop deployment or service for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating network security policies for team '${team}'`);
@@ -393,7 +393,7 @@ async function createTeam(req, res) {
     logger.info(`Created network security policies for team  '${team}'`);
   } catch (error) {
     logger.error(`Error while network security policies for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -430,7 +430,7 @@ async function createAWSTeam(req, res) {
     await createNameSpaceForTeam(team);
   } catch (error) {
     logger.error(`Error while creating namespace for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating Configmap for team '${team}'`);
@@ -441,7 +441,7 @@ async function createAWSTeam(req, res) {
     await createChallenge33SecretForTeam(team);
   } catch (error) {
     logger.error(`Error while creating secretsfile or configmap for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating challenge62 secret and configmap for team '${team}'`);
@@ -449,7 +449,7 @@ async function createAWSTeam(req, res) {
     await createChallenge62ConfigMapForTeam(team);
   } catch (error) {
     logger.error(`Error while creating challenge62 resources for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(
@@ -458,7 +458,7 @@ async function createAWSTeam(req, res) {
     await createAWSSecretsProviderForTeam(team);
   } catch (error) {
     logger.error(`Error while creating Secretsprovider for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -466,7 +466,7 @@ async function createAWSTeam(req, res) {
     await patchServiceAccountForTeamForAWS(team);
   } catch (error) {
     logger.error(`Error while annotating the service account for  ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -477,7 +477,7 @@ async function createAWSTeam(req, res) {
     logger.error(
       `Error while creating wrongsecrets deployment or service for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -488,7 +488,7 @@ async function createAWSTeam(req, res) {
     logger.error(
       `Error while creating service account for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -497,7 +497,7 @@ async function createAWSTeam(req, res) {
     logger.info(`Created challenge53 Deployment for team '${team}'`);
   } catch (error) {
     logger.error(`Error while creating challenge53 deployment for team ${team}: ${error.message}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -508,7 +508,7 @@ async function createAWSTeam(req, res) {
     logger.error(
       `Error while creating role for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -519,7 +519,7 @@ async function createAWSTeam(req, res) {
     logger.error(
       `Error while creating roleBinding for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -532,7 +532,7 @@ async function createAWSTeam(req, res) {
     logger.error(
       `Error while creating Virtualdesktop deployment or service for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -542,7 +542,7 @@ async function createAWSTeam(req, res) {
     logger.info(`Created network security policies for team  '${team}'`);
   } catch (error) {
     logger.error(`Error while network security policies for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -577,7 +577,7 @@ async function createAzureTeam(req, res) {
     await createNameSpaceForTeam(team);
   } catch (error) {
     logger.error(`Error while creating namespace for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating Configmap for team '${team}'`);
@@ -588,7 +588,7 @@ async function createAzureTeam(req, res) {
     await createChallenge33SecretForTeam(team);
   } catch (error) {
     logger.error(`Error while creating secretsfile or configmap for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating challenge62 secret and configmap for team '${team}'`);
@@ -596,7 +596,7 @@ async function createAzureTeam(req, res) {
     await createChallenge62ConfigMapForTeam(team);
   } catch (error) {
     logger.error(`Error while creating challenge62 resources for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(
@@ -605,7 +605,7 @@ async function createAzureTeam(req, res) {
     await createAzureSecretsProviderForTeam(team);
   } catch (error) {
     logger.error(`Error while creating Secretsprovider for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -616,7 +616,7 @@ async function createAzureTeam(req, res) {
     logger.error(
       `Error while creating wrongsecrets deployment or service for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -627,7 +627,7 @@ async function createAzureTeam(req, res) {
     logger.error(
       `Error while creating service account for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -636,7 +636,7 @@ async function createAzureTeam(req, res) {
     logger.info(`Created challenge53 Deployment for team '${team}'`);
   } catch (error) {
     logger.error(`Error while creating challenge53 deployment for team ${team}: ${error.message}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -647,7 +647,7 @@ async function createAzureTeam(req, res) {
     logger.error(
       `Error while creating role for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -658,7 +658,7 @@ async function createAzureTeam(req, res) {
     logger.error(
       `Error while creating roleBinding for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -671,7 +671,7 @@ async function createAzureTeam(req, res) {
     logger.error(
       `Error while creating Virtualdesktop deployment or service for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -681,7 +681,7 @@ async function createAzureTeam(req, res) {
     logger.info(`Created network security policies for team  '${team}'`);
   } catch (error) {
     logger.error(`Error while network security policies for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -716,7 +716,7 @@ async function createGCPTeam(req, res) {
     await createNameSpaceForTeam(team);
   } catch (error) {
     logger.error(`Error while creating namespace for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating Configmap for team '${team}'`);
@@ -727,7 +727,7 @@ async function createGCPTeam(req, res) {
     await createChallenge33SecretForTeam(team);
   } catch (error) {
     logger.error(`Error while creating secretsfile or configmap for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(`Creating challenge62 secret and configmap for team '${team}'`);
@@ -735,7 +735,7 @@ async function createGCPTeam(req, res) {
     await createChallenge62ConfigMapForTeam(team);
   } catch (error) {
     logger.error(`Error while creating challenge62 resources for ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     logger.info(
@@ -744,7 +744,7 @@ async function createGCPTeam(req, res) {
     await createGCPSecretsProviderForTeam(team);
   } catch (error) {
     logger.error(`Error while creating Secretsprovider for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -753,7 +753,7 @@ async function createGCPTeam(req, res) {
     logger.info(`Created IAM service account for team '${team}'`);
   } catch (error) {
     logger.error(`Error while creating IAM service account for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -762,7 +762,7 @@ async function createGCPTeam(req, res) {
     logger.info(`Bound IAM service account to workload for team '${team}'`);
   } catch (error) {
     logger.error(`Error while binding IAM service account to workload for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -770,7 +770,7 @@ async function createGCPTeam(req, res) {
     await patchServiceAccountForTeamForGCP(team);
   } catch (error) {
     logger.error(`Error while annotating the service account for  ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -781,7 +781,7 @@ async function createGCPTeam(req, res) {
     logger.error(
       `Error while creating wrongsecrets deployment or service for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -792,7 +792,7 @@ async function createGCPTeam(req, res) {
     logger.error(
       `Error while creating service account for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -801,7 +801,7 @@ async function createGCPTeam(req, res) {
     logger.info(`Created challenge53 Deployment for team '${team}'`);
   } catch (error) {
     logger.error(`Error while creating challenge53 deployment for team ${team}: ${error.message}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -812,7 +812,7 @@ async function createGCPTeam(req, res) {
     logger.error(
       `Error while creating role for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -823,7 +823,7 @@ async function createGCPTeam(req, res) {
     logger.error(
       `Error while creating roleBinding for virtual desktop for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -836,7 +836,7 @@ async function createGCPTeam(req, res) {
     logger.error(
       `Error while creating Virtualdesktop deployment or service for team ${team}: ${error.message}`
     );
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
 
   try {
@@ -846,7 +846,7 @@ async function createGCPTeam(req, res) {
     logger.info(`Created network security policies for team  '${team}'`);
   } catch (error) {
     logger.error(`Error while network security policies for team ${team}: ${error}`);
-    res.status(500).send({ message: 'Failed to Create Instance' });
+    return res.status(500).send({ message: 'Failed to Create Instance' });
   }
   try {
     loginCounter.inc({ type: 'registration', userType: 'user' }, 1);

--- a/wrongsecrets-balancer/src/teams/teams.test.js
+++ b/wrongsecrets-balancer/src/teams/teams.test.js
@@ -188,6 +188,23 @@ test('create team creates a instance for team via k8s service', async () => {
   expect(createServiceForTeam).toHaveBeenCalledWith('team42');
 });
 
+test('create team fails when namespace creation throws an error', async () => {
+  getJuiceShopInstanceForTeamname.mockImplementation(async () => {
+    throw new Error(`deployments.apps "t-team42-wrongsecrets" not found`);
+  });
+  createNameSpaceForTeam.mockImplementation(async () => {
+    throw new Error('Kubernetes API error');
+  });
+
+  await request(app)
+    .post('/balancer/teams/team42/join')
+    .send({ hmacvalue: '4c8dd1f1306727c537aa96f0c59968b719740f2a30ccda92044ea59622565564' })
+    .expect(500);
+
+  expect(createConfigmapForTeam).not.toHaveBeenCalled();
+  expect(createSecretsfileForTeam).not.toHaveBeenCalled();
+});
+
 test('reset passcode needs authentication if no cookie is sent', async () => {
   await request(app).post('/balancer/teams/reset-passcode').send().expect(401);
 });


### PR DESCRIPTION
## Summary

This PR fixes an issue where the balancer's team provisioning handlers continued executing subsequent resource provisioning steps after an intermediate failure. The change ensures that execution stops immediately after an error response is sent, preventing duplicate HTTP responses and unnecessary Kubernetes API calls.

Closes #1286

## Problem

During team creation, the balancer provisions multiple Kubernetes resources sequentially, including namespaces, ConfigMaps, Secrets, deployments, roles, and role bindings.

If one of the intermediate provisioning steps fails, the corresponding error handler returns a `500 Internal Server Error` response but continues executing the remaining provisioning logic. As a result:

- Additional provisioning steps continue unnecessarily after the request has already failed.
- The handler eventually attempts to send a success response, resulting in `ERR_HTTP_HEADERS_SENT` errors.
- Unnecessary Kubernetes API calls are made after a failed provisioning step.

This affects the following handlers in `wrongsecrets-balancer/src/teams/teams.js`:

- `createTeam`
- `createAWSTeam`
- `createAzureTeam`
- `createGCPTeam`

## Root Cause

The error handlers for intermediate provisioning steps send an error response but do not terminate the request handler, allowing execution to continue through the remaining provisioning steps.

## Solution

Terminate the request handler immediately after sending an error response during any intermediate provisioning failure.

This ensures that:

- No additional provisioning operations are executed after a failure.
- Only a single HTTP response is sent for each request.
- `ERR_HTTP_HEADERS_SENT` errors are avoided.

## Testing

- Added a regression test covering namespace creation failure.
- Verified that subsequent provisioning functions are not executed after the failure.
- Ran `npm test` successfully (**38 tests passed**).
- Ran `npm run lint` successfully (**no linting issues**).

## Checklist

- [x] My code follows the project's coding style.
- [x] I have added or updated tests to cover the change.
- [x] All new and existing tests pass.
- [x] Lint checks pass successfully.