### PR TITLE
Remove Docker images publish badge from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,6 @@ _Powered by MultiJuicer_
 [![WrongSecrets CTF Party: E2E Tests](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/e2e-tests.yml)
 [![Test minikube script (k8s)](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/minikube-k8s-test.yml/badge.svg)](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/minikube-k8s-test.yml)
 [![Preview Deployment](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/preview.yml/badge.svg)](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/preview.yml)
-[![Publish Docker Images](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/publish.yml/badge.svg)](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/publish.yml)
 [![Deploy static content to Pages](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/pages.yml/badge.svg)](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/pages.yml)
 [![Release Management](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/release-notes.yaml/badge.svg)](https://github.com/OWASP/wrongsecrets-ctf-party/actions/workflows/release-notes.yaml)
 


### PR DESCRIPTION
Removed the badge for publishing Docker images from the README.

Thank you for submitting a pull request to the WrongSecrets Party!

What kind of changes does this PR include?

-   [ ] Fixes or refactors
-   [ ] Platform support
-   [ ] A new feature
-   [ ] Additional documentation
-   [ ] Something else

Checklist:

-   [ ] All the contributions made are solely the work of me and my co-authors
-   [ ] I tested the changes in this PR (if applicable)
-   [ ] I added tests to ensure my change works (if applicable)
-   [ ] The PR passes pre-commit hooks and automated tests
