### PR TITLE
test(e2e): capture Kubernetes diagnostics on Cypress failure

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,3 +48,17 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 300
           browser: chrome
+
+      - name: Dump Kubernetes Diagnostics on Failure
+        if: failure()
+        run: |
+          echo "=== KUBERNETES NAMESPACES ==="
+          kubectl get namespaces || true
+          echo "=== KUBERNETES PODS (ALL NAMESPACES) ==="
+          kubectl get pods -A -o wide || true
+          echo "=== KUBERNETES DEPLOYMENTS (ALL NAMESPACES) ==="
+          kubectl get deployments -A -o wide || true
+          echo "=== KUBERNETES EVENTS (ALL NAMESPACES) ==="
+          kubectl get events -A --sort-by='.metadata.creationTimestamp' | tail -n 50 || true
+          echo "=== BALANCER POD LOGS ==="
+          kubectl logs -l app=wrongsecrets-balancer -A --tail=300 || true


### PR DESCRIPTION
### Summary
Adds a post-test diagnostic dump step to the Cypress E2E GitHub Actions workflow that executes only when the E2E tests fail.

### Why this change is needed
Flaky E2E failures are difficult to diagnose in the CI environment without visibility into the Kubernetes cluster state (e.g., pod statuses, events, and balancer controller logs). During recent CI runs, failures occurred (such as connection timeouts or 500 responses) where the exact state of the backend balancer pod and instance pods was unknown. 

These diagnostics provide immediate context inside the GitHub Actions workflow logs on any E2E failure.

### What changed
* **[.github/workflows/e2e-tests.yml](file:///.github/workflows/e2e-tests.yml)**: Added a step `Dump Kubernetes Diagnostics on Failure` running on `if: failure()`.
  * Dumps active namespaces (`kubectl get namespaces`).
  * Lists all pods with node details (`kubectl get pods -A -o wide`).
  * Lists all deployments (`kubectl get deployments -A -o wide`).
  * Captures the last 50 Kubernetes events sorted by creation timestamp (`kubectl get events -A`).
  * Dumps the tail logs of balancer pods across namespaces using a label selector (`kubectl logs -l app=wrongsecrets-balancer -A --tail=300`).
  * Guarded every diagnostic command with `|| true` to ensure that a failure in the diagnostic toolchain never masks the original Cypress failure.

### Verification Performed
* **YAML Validation**: Checked syntax and indentation of the `.github/workflows/e2e-tests.yml` changes against the project's workflow structure.

### Maintainer Notes
* All diagnostic commands are scoped to execute only on E2E task failures (`if: failure()`). They will not interfere with successful runs or add log noise.
* Ref: Addresses maintainer discussion regarding the need to capture more E2E debugging logs.
