### PR TITLE
fix(balancer): handle missing deployment during readiness checks

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,3 +48,17 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 300
           browser: chrome
+
+      - name: Dump Kubernetes Diagnostics on Failure
+        if: failure()
+        run: |
+          echo "=== KUBERNETES NAMESPACES ==="
+          kubectl get namespaces || true
+          echo "=== KUBERNETES PODS (ALL NAMESPACES) ==="
+          kubectl get pods -A -o wide || true
+          echo "=== KUBERNETES DEPLOYMENTS (ALL NAMESPACES) ==="
+          kubectl get deployments -A -o wide || true
+          echo "=== KUBERNETES EVENTS (ALL NAMESPACES) ==="
+          kubectl get events -A --sort-by='.metadata.creationTimestamp' | tail -n 50 || true
+          echo "=== BALANCER POD LOGS ==="
+          kubectl logs -l app=wrongsecrets-balancer -A --tail=300 || true

--- a/wrongsecrets-balancer/src/teams/teams.js
+++ b/wrongsecrets-balancer/src/teams/teams.js
@@ -951,7 +951,8 @@ async function awaitReadiness(req, res) {
   logger.info(`Awaiting readiness of wrongsecrets Deployment for team '${team}'`);
   for (let i = 0; i < 180; i++) {
     try {
-      const { readyReplicas } = await getJuiceShopInstanceForTeamname(team);
+      const instance = await getJuiceShopInstanceForTeamname(team);
+      const readyReplicas = instance ? instance.readyReplicas : 0;
 
       if (readyReplicas === 1) {
         logger.info(`wrongsecrets Deployment for team '${team}' ready`);

--- a/wrongsecrets-balancer/src/teams/teams.test.js
+++ b/wrongsecrets-balancer/src/teams/teams.test.js
@@ -288,3 +288,19 @@ test('reset passcode resets passcode to new value if team exists', async () => {
   expect(callArgs[0]).toBe(team);
   expect(bcrypt.compareSync(newPasscode, callArgs[1])).toBe(true);
 });
+
+describe('wait-till-ready polling', () => {
+  test('returns 200 immediately if deployment is already ready', async () => {
+    getJuiceShopInstanceForTeamname.mockResolvedValue({ readyReplicas: 1 });
+
+    await request(app).get('/balancer/teams/team42/wait-till-ready').expect(200);
+  });
+
+  test('handles transient undefined (missing deployment) and resolves on next check', async () => {
+    getJuiceShopInstanceForTeamname
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ readyReplicas: 1 });
+
+    await request(app).get('/balancer/teams/team42/wait-till-ready').expect(200);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a race condition in the balancer's `wait-till-ready` polling logic where a transient `404` (deployment not yet registered in Kubernetes API) caused a crash (`TypeError`) and immediately aborted the polling loop.

## Why this change is needed

When a team is created, the client is redirected to the dashboard, which polls `/balancer/teams/:team/wait-till-ready`.

If the Kubernetes API is slightly slow to register the deployment, the API call to read the deployment details returns `404`. Under the hood, `getJuiceShopInstanceForTeamname` catches this and returns `undefined`.

In `teams.js`, the code was destructuring `readyReplicas` directly from the result:

```javascript
const { readyReplicas } = await getJuiceShopInstanceForTeamname(team);  
```

Since the result was undefined, this threw a TypeError: Cannot destructure property 'readyReplicas' ... as it is undefined., causing the route to return 500 immediately and fail the Cypress E2E test.

## What changed

- `wrongsecrets-balancer/src/teams/teams.js`: Modified the polling loop to check if the returned instance is defined before reading `readyReplicas`, defaulting to `0` and letting the polling loop sleep and retry (consistent with existing readiness retry design) rather than crashing.

- `wrongsecrets-balancer/src/teams/teams.test.js`: Added two Jest unit tests verifying:
  - Immediate success when the deployment is ready (`readyReplicas === 1`).
  - Clean polling retry and eventual resolution when the deployment is initially `undefined` (transient 404).
  - Verification Performed
  
## Unit Tests: Executed npm test inside wrongsecrets-balancer. All 61 unit tests passed (including the new readiness tests).

- Code Linting: Verified that npm run lint completes cleanly with no warnings or syntax errors.
- Cypress E2E Note: Cypress was not run locally as Minikube/Kubernetes infrastructure was unavailable on the local machine. The workflow is designed to run against the real Minikube runner in CI.

## Maintainer Notes

- The existing success logic (readyReplicas === 1) and loop retry thresholds (180 iterations of 4 seconds) are preserved exactly.
- Fixes flakiness observed in recent E2E runs where the container creation phase timed out or threw an HTTP 500 error before the instance became ready.